### PR TITLE
fix: registration for template python lifecycle component

### DIFF
--- a/source/template_component_package/setup.cfg
+++ b/source/template_component_package/setup.cfg
@@ -2,4 +2,4 @@
 python_components =
     # register Python components
     template_component_package::PyComponent = template_component_package.py_component:PyComponent
-    template_component_package::PyLifecycleComponent = template_component_package.py_component:PyLifecycleComponent
+    template_component_package::PyLifecycleComponent = template_component_package.py_lifecycle_component:PyLifecycleComponent


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

I found a small typo in the registration for the template python lifecycle component.

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 0.1 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->