### PR TITLE
feat: promote on step callback for components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,18 @@
 {
-    "cmake.sourceDirectory": "/home/ros2/ws/src/template_component_package",
-    "clang-format.fallbackStyle": "none",
-    "clang-format.language.cpp.style": "file:/home/ros2/.clang-format",
-    "C_Cpp.intelliSenseEngine": "disabled",
-    "[cpp]": {
-        "editor.defaultFormatter": "xaver.clang-format",
-        "editor.inlayHints.enabled": "on"
-    },
-    "editor.rulers": [
-        120
-    ],
-    "ruff.nativeServer": "on",
-    "ruff.lineLength": 120,
+  "cmake.sourceDirectory": "/home/ros2/ws/src/template_component_package",
+  "clang-format.fallbackStyle": "none",
+  "clang-format.language.cpp.style": "file:/home/ros2/.clang-format",
+  "C_Cpp.intelliSenseEngine": "disabled",
+  "[cpp]": {
+    "editor.defaultFormatter": "xaver.clang-format",
+    "editor.inlayHints.enabled": "on"
+  },
+  "editor.rulers": [
+    120
+  ],
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "ruff.nativeServer": "on",
+  "ruff.lineLength": 120,
 }

--- a/source/template_component_package/include/template_component_package/CPPComponent.hpp
+++ b/source/template_component_package/include/template_component_package/CPPComponent.hpp
@@ -10,6 +10,8 @@ public:
 protected:
   bool on_validate_parameter_callback(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override;
 
-  bool on_execute_callback() override;
+  void on_step_callback() override;
+
+  // bool on_execute_callback() override;
 };
 }  // namespace template_component_package

--- a/source/template_component_package/include/template_component_package/CPPComponent.hpp
+++ b/source/template_component_package/include/template_component_package/CPPComponent.hpp
@@ -8,10 +8,11 @@ public:
   explicit CPPComponent(const rclcpp::NodeOptions& options);
 
 protected:
-  bool on_validate_parameter_callback(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override;
+  bool
+  on_validate_parameter_callback(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override;
 
   void on_step_callback() override;
 
   // bool on_execute_callback() override;
 };
-}  // namespace template_component_package
+}// namespace template_component_package

--- a/source/template_component_package/include/template_component_package/CPPLifecycleComponent.hpp
+++ b/source/template_component_package/include/template_component_package/CPPLifecycleComponent.hpp
@@ -8,11 +8,12 @@ public:
   explicit CPPLifecycleComponent(const rclcpp::NodeOptions& options);
 
 protected:
-  bool on_validate_parameter_callback(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override;
+  bool
+  on_validate_parameter_callback(const std::shared_ptr<state_representation::ParameterInterface>& parameter) override;
 
   bool on_configure_callback() override;
   bool on_activate_callback() override;
   bool on_deactivate_callback() override;
   void on_step_callback() override;
 };
-}  // namespace template_component_package
+}// namespace template_component_package

--- a/source/template_component_package/src/CPPComponent.cpp
+++ b/source/template_component_package/src/CPPComponent.cpp
@@ -1,8 +1,7 @@
 #include "template_component_package/CPPComponent.hpp"
 
 namespace template_component_package {
-CPPComponent::CPPComponent(const rclcpp::NodeOptions& options) :
-    modulo_components::Component(options, "CPPComponent") {
+CPPComponent::CPPComponent(const rclcpp::NodeOptions& options) : modulo_components::Component(options, "CPPComponent") {
   // add parameters, inputs and outputs here
 }
 
@@ -26,7 +25,7 @@ void CPPComponent::on_step_callback() {
 //   return true;
 // }
 
-} // namespace template_component_package
+}// namespace template_component_package
 
 #include "rclcpp_components/register_node_macro.hpp"
 

--- a/source/template_component_package/src/CPPComponent.cpp
+++ b/source/template_component_package/src/CPPComponent.cpp
@@ -11,7 +11,7 @@ bool CPPComponent::on_validate_parameter_callback(const std::shared_ptr<state_re
   return true;
 }
 
-void CppComponent::on_step_callback() {
+void CPPComponent::on_step_callback() {
   return;
 }
 

--- a/source/template_component_package/src/CPPComponent.cpp
+++ b/source/template_component_package/src/CPPComponent.cpp
@@ -11,15 +11,20 @@ bool CPPComponent::on_validate_parameter_callback(const std::shared_ptr<state_re
   return true;
 }
 
-bool CPPComponent::on_execute_callback() {
-  // If the component needs to do any post-construction behavior, invoke `execute()`
-  // at the end of the constructor, which will trigger this callback in a separate thread.
-  // This is only necessary when the behavior would otherwise block the constructor from completing
-  // in a timely manner, such as some time-intensive computation or waiting for an external trigger.
-
-  // return true if the execution was successful, false otherwise
-  return true;
+void CppComponent::on_step_callback() {
+  return;
 }
+
+// bool CPPComponent::on_execute_callback() {
+//   // If the component needs to do any post-construction behavior, invoke `execute()`
+//   // at the end of the constructor, which will trigger this callback in a separate thread.
+//   // This is only necessary when the behavior would otherwise block the constructor from completing
+//   // in a timely manner, such as some time-intensive computation or waiting for an external trigger.
+//   // This behavoir is mutually exclusive with the periodic behavior of `on_step_callback`.
+
+//   // return true if the execution was successful, false otherwise
+//   return true;
+// }
 
 } // namespace template_component_package
 

--- a/source/template_component_package/src/CPPLifecycleComponent.cpp
+++ b/source/template_component_package/src/CPPLifecycleComponent.cpp
@@ -1,13 +1,13 @@
 #include "template_component_package/CPPLifecycleComponent.hpp"
 
 namespace template_component_package {
-CPPLifecycleComponent::CPPLifecycleComponent(const rclcpp::NodeOptions& options) :
-    modulo_components::LifecycleComponent(options, "CPPLifecycleComponent") {
+CPPLifecycleComponent::CPPLifecycleComponent(const rclcpp::NodeOptions& options)
+    : modulo_components::LifecycleComponent(options, "CPPLifecycleComponent") {
   // add parameters, inputs and outputs here
 }
 
-bool
-CPPLifecycleComponent::on_validate_parameter_callback(const std::shared_ptr<state_representation::ParameterInterface>&) {
+bool CPPLifecycleComponent::on_validate_parameter_callback(
+    const std::shared_ptr<state_representation::ParameterInterface>&) {
   // validate an incoming parameter value according to some criteria
   return true;
 }
@@ -31,7 +31,7 @@ void CPPLifecycleComponent::on_step_callback() {
   // do something periodically
 }
 
-} // namespace template_component_package
+}// namespace template_component_package
 
 #include "rclcpp_components/register_node_macro.hpp"
 

--- a/source/template_component_package/template_component_package/py_component.py
+++ b/source/template_component_package/template_component_package/py_component.py
@@ -1,5 +1,5 @@
-from modulo_components.component import Component
 import state_representation as sr
+from modulo_components.component import Component
 
 
 class PyComponent(Component):
@@ -10,7 +10,7 @@ class PyComponent(Component):
     def on_validate_parameter_callback(self, parameter: sr.Parameter) -> bool:
         # validate an incoming parameter value according to some criteria
         return True
-    
+
     def on_step_callback(self):
         # do something periodically
         pass

--- a/source/template_component_package/template_component_package/py_component.py
+++ b/source/template_component_package/template_component_package/py_component.py
@@ -10,12 +10,17 @@ class PyComponent(Component):
     def on_validate_parameter_callback(self, parameter: sr.Parameter) -> bool:
         # validate an incoming parameter value according to some criteria
         return True
+    
+    def on_step_callback(self):
+        # do something periodically
+        pass
 
-    def on_execute_callback(self) -> bool:
-        # If the component needs to do any post-construction behavior, invoke `self.execute()`
-        # at the end of the constructor, which will trigger this callback in a separate thread.
-        # This is only necessary when the behavior would otherwise block the constructor from completing
-        # in a timely manner, such as some time-intensive computation or waiting for an external trigger.
+    # def on_execute_callback(self) -> bool:
+    #     # If the component needs to do any post-construction behavior, invoke `self.execute()`
+    #     # at the end of the constructor, which will trigger this callback in a separate thread.
+    #     # This is only necessary when the behavior would otherwise block the constructor from completing
+    #     # in a timely manner, such as some time-intensive computation or waiting for an external trigger.
+    #     # This behavoir is mutually exclusive with the periodic behavior of `on_step_callback`.
 
-        # return True if the execution was successful, False otherwise
-        return True
+    #     # return True if the execution was successful, False otherwise
+    #     return True

--- a/source/template_component_package/template_component_package/py_lifecycle_component.py
+++ b/source/template_component_package/template_component_package/py_lifecycle_component.py
@@ -1,5 +1,5 @@
-from modulo_components.lifecycle_component import LifecycleComponent
 import state_representation as sr
+from modulo_components.lifecycle_component import LifecycleComponent
 
 
 class PyLifecycleComponent(LifecycleComponent):

--- a/source/template_component_package/test/cpp_tests/test_cpp_component.cpp
+++ b/source/template_component_package/test/cpp_tests/test_cpp_component.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 #include <rclcpp_components/component_manager.hpp>
 
-
 class TestCPPComponent : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -14,14 +13,11 @@ protected:
     exec_->add_node(manager_);
   }
 
-  void TearDown() override {
-    rclcpp::shutdown();
-  }
+  void TearDown() override { rclcpp::shutdown(); }
 
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> exec_;
   std::shared_ptr<rclcpp_components::ComponentManager> manager_;
 };
-
 
 TEST_F(TestCPPComponent, test_component_load) {
   auto resources = manager_->get_component_resources("template_component_package");

--- a/source/template_component_package/test/cpp_tests/test_cpp_lifecycle_component.cpp
+++ b/source/template_component_package/test/cpp_tests/test_cpp_lifecycle_component.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 #include <rclcpp_components/component_manager.hpp>
 
-
 class TestCPPLifecycleComponent : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -14,14 +13,11 @@ protected:
     exec_->add_node(manager_);
   }
 
-  void TearDown() override {
-    rclcpp::shutdown();
-  }
-  
+  void TearDown() override { rclcpp::shutdown(); }
+
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> exec_;
   std::shared_ptr<rclcpp_components::ComponentManager> manager_;
 };
-
 
 TEST_F(TestCPPLifecycleComponent, test_component_load) {
   auto resources = manager_->get_component_resources("template_component_package");

--- a/source/template_component_package/test/python_tests/test_py_component.py
+++ b/source/template_component_package/test/python_tests/test_py_component.py
@@ -1,12 +1,11 @@
 import pytest
-
 from template_component_package.py_component import PyComponent
 
 
 @pytest.fixture()
 def py_component(ros_context):
-    yield PyComponent('py_component')
+    yield PyComponent("py_component")
 
 
 def test_construction(py_component):
-    assert py_component.get_name() == 'py_component'
+    assert py_component.get_name() == "py_component"

--- a/source/template_component_package/test/python_tests/test_py_lifecycle_component.py
+++ b/source/template_component_package/test/python_tests/test_py_lifecycle_component.py
@@ -1,12 +1,11 @@
 import pytest
-
 from template_component_package.py_lifecycle_component import PyLifecycleComponent
 
 
 @pytest.fixture()
 def py_lifecycle_component(ros_context):
-    yield PyLifecycleComponent('py_lifecycle_component')
+    yield PyLifecycleComponent("py_lifecycle_component")
 
 
 def test_construction(py_lifecycle_component):
-    assert py_lifecycle_component.get_name() == 'py_lifecycle_component'
+    assert py_lifecycle_component.get_name() == "py_lifecycle_component"


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
This PR puts emphasize on the step callback of non lifecycle components instead of the `execute` behavior, which is an edge case. I had it twice now from different users that they meant to do stuff periodically but put that into the `on_execute_callback` which is already there in the template instead of overriding `on_step_callback` which is missing in the template

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ N/A] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->