### PR TITLE
fix: remove ament_python_install_package for cpp-only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 /build
 compile_commands.json
+.*CommandMarker

--- a/initialize_package.sh
+++ b/initialize_package.sh
@@ -322,6 +322,10 @@ if [[ -f "${CMAKE_FILE}" ]]; then
         echo "Removing C++ lifecycle component registration..."
         sed_inplace '/Register CPPLifecycleComponent/,/COMPONENTS cpp_lifecycle_component)/d' "${CMAKE_FILE}"
       fi
+      if [[ "${INCLUDE_PYTHON}" == "no" ]]; then
+        echo "Removing ament_python_install_package() from CMakeLists.txt..."
+        sed_inplace '/ament_python_install_package\s*(.*)/d' "${CMAKE_FILE}"
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- n/a

We have a problem when using the `initialize_package.sh` to create a C++ only package, as it leaves behind the `ament_python_install_package` command and ultimately fails to build.  

New tests on this are appreciated.

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by seding this out if needed. I also added the CommandMarker files to gitignore since we are here

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->