### PR TITLE
fix: base image version and extension schemas

### DIFF
--- a/.init_wizard/templates/.devcontainer/devcontainer.json.j2
+++ b/.init_wizard/templates/.devcontainer/devcontainer.json.j2
@@ -18,6 +18,7 @@
       "extensions": [
         "ms-vscode.cpptools-extension-pack",
         "llvm-vs-code-extensions.vscode-clangd",
+        "redhat.vscode-yaml",
         "xaver.clang-format",
         "charliermarsh.ruff"
       ]

--- a/.init_wizard/templates/.vscode/settings.json.j2
+++ b/.init_wizard/templates/.vscode/settings.json.j2
@@ -16,7 +16,7 @@
   "ruff.nativeServer": "on",
   "ruff.lineLength": 120,
   "yaml.schemas": {
-    "https://raw.githubusercontent.com/aica-technology/api/731960c66a8fb9b29620a9f79baaa935818ab1db/docs/static/schemas/1-0-2/extension.schema.json": [
+    "https://raw.githubusercontent.com/aica-technology/api/5583d2afea6b327fca809d27acefcbbdf5950238/docs/static/schemas/1-0-3/extension.schema.json": [
         "extension_descriptions/*.yaml"
     ]
   }

--- a/.init_wizard/templates/aica-package.toml.j2
+++ b/.init_wizard/templates/aica-package.toml.j2
@@ -14,7 +14,7 @@ version = "0.0.1"
 
 [build]
 type = "ros"
-image = "v2.0.5-jazzy"
+image = "v2.0.6-jazzy"
 
 [build.cmake-args]
 ## add any cmake args here, e.g.

--- a/.init_wizard/templates/component/extension_descriptions/package_name_cpp_component.yaml.j2
+++ b/.init_wizard/templates/component/extension_descriptions/package_name_cpp_component.yaml.j2
@@ -1,4 +1,4 @@
-schema: 1-0-2
+schema: 1-0-3
 name: Template CPP Component
 description:
   brief: Brief description of the component

--- a/.init_wizard/templates/component/extension_descriptions/package_name_cpp_lifecycle_component.yaml.j2
+++ b/.init_wizard/templates/component/extension_descriptions/package_name_cpp_lifecycle_component.yaml.j2
@@ -1,4 +1,4 @@
-schema: 1-0-2
+schema: 1-0-3
 name: Template CPP Lifecycle Component
 description:
   brief: Brief description of the component

--- a/.init_wizard/templates/component/extension_descriptions/package_name_py_component.yaml.j2
+++ b/.init_wizard/templates/component/extension_descriptions/package_name_py_component.yaml.j2
@@ -1,4 +1,4 @@
-schema: 1-0-2
+schema: 1-0-3
 name: Template Python Component
 description:
   brief: Brief description of the component

--- a/.init_wizard/templates/component/extension_descriptions/package_name_py_lifecycle_component.yaml.j2
+++ b/.init_wizard/templates/component/extension_descriptions/package_name_py_lifecycle_component.yaml.j2
@@ -1,4 +1,4 @@
-schema: 1-0-2
+schema: 1-0-3
 name: Template Python Lifecycle Component
 description:
   brief: Brief description of the component

--- a/.init_wizard/templates/controller/extension_descriptions/package_name_controller_name_snake.yaml.j2
+++ b/.init_wizard/templates/controller/extension_descriptions/package_name_controller_name_snake.yaml.j2
@@ -1,4 +1,4 @@
-schema: 1-0-2
+schema: 1-0-3
 name: "{{ controller_name }}"
 description:
   brief: Brief description of the controller


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

There was a bug that prevented extension descriptions from being included in the build, because 2.0.5-jazzy base image was used instead of the newer 2.0.6-jazzy image.

This PR makes this upgrade, also upgrades extension schema version to 1-0-3 (though it includes no functional change), and finally includes the yaml extension in the devcontainer to ensure syntax validation happens automatically.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [N/A] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->